### PR TITLE
Run GHDL in workspaceRoot in SpinalTesterGhdlBase

### DIFF
--- a/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
+++ b/tester/src/main/scala/spinal/tester/scalatest/SpinalTesterGhdlBase.scala
@@ -3,10 +3,12 @@ package spinal.tester.scalatest
 import org.scalatest.funsuite.AnyFunSuite
 import spinal.core._
 
+import java.io.File
 import scala.sys.process._
 
 abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
   def workspaceRoot = "./simWorkspace"
+  def workspaceFile = new File(workspaceRoot)
   var withWaveform = false
   var elaborateMustFail = false
   var checkHDLMustFail = false
@@ -16,7 +18,6 @@ abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
     testIt
     postTest
   }
-
 
   def testIt: Unit = {
     if(!elaborateMustFail) elaborate else elaborateWithFail
@@ -44,34 +45,30 @@ abstract class SpinalTesterGhdlBase extends AnyFunSuite  {
     }
   }
 
-
-  def checkHDL(mustSuccess: Boolean): Unit = {
-    val comp = s"ghdl -a --ieee=synopsys --work=$getLibraryName --workdir=$workspaceRoot $workspaceRoot/$getName.vhd tester/src/test/resources/${getName}_tb.vhd"
+  def checkHDL(mustSucceed: Boolean): Unit = {
+    val tester = new File(s"tester/src/test/resources/${getName}_tb.vhd").getAbsoluteFile
+    val comp = s"ghdl -a --ieee=synopsys --work=$getLibraryName --workdir=. $getName.vhd $tester"
     println("GHDL compilation " + comp)
-    assert(((comp !) == 0) == mustSuccess, if (mustSuccess) "compilation fail" else "Compilation has not fail :(")
+    assert((Process(comp, workspaceFile).! == 0) == mustSucceed, if (mustSucceed) "compilation fail" else "Compilation did not fail :(")
 
-
-    val elab = s"ghdl -e --ieee=synopsys --work=$getLibraryName --workdir=$workspaceRoot ${getName}_tb"
+    val elab = s"ghdl -e --ieee=synopsys --work=$getLibraryName --workdir=. ${getName}_tb"
     println("GHDL elaborate " + elab)
-    assert(((elab !) == 0) == mustSuccess, if (mustSuccess) "compilation fail" else "Compilation has not fail :(")
+    assert((Process(elab, workspaceFile).! == 0) == mustSucceed, if (mustSucceed) "compilation fail" else "Compilation did not fail :(")
   }
 
   def checkHDL: Unit = checkHDL(true)
   def checkHDLWithFail: Unit = checkHDL(false)
 
-
   def simulateHDL : Unit= simulateHDL(true)
   def simulateHDLWithFail : Unit= simulateHDL(false)
 
-  def simulateHDL(mustSuccess : Boolean): Unit = {
-    val run = s"ghdl -r --ieee=synopsys --work=$getLibraryName --workdir=$workspaceRoot ${getName}_tb --ieee-asserts=disable ${if (!withWaveform) "" else s" --vcd=$getName.vcd"}"
+  def simulateHDL(mustSucceed : Boolean): Unit = {
+    val run = s"ghdl -r --ieee=synopsys --work=$getLibraryName --workdir=. ${getName}_tb --ieee-asserts=disable ${if (!withWaveform) "" else s" --vcd=$getName.vcd"}"
     println("GHDL run " + run)
-    val ret = (run !)
-    assert(!mustSuccess || ret == 0,"Simulation fail")
-    assert(mustSuccess || ret != 0,"Simulation has not fail :(")
+    val ret = Process(run, new File(workspaceRoot)).!
+    assert(!mustSucceed || ret == 0,"Simulation fail")
+    assert(mustSucceed || ret != 0,"Simulation did not fail :(")
   }
-
-
 
   def getName: String
   def createToplevel: Component


### PR DESCRIPTION
GHDL will always write binaries and some library files to the current working directory (and ignore --workdir for those). Run GHDL directly in the workspaceRoot.

<!-- Note: text surrounded by these delimiters will not appear in the PR. -->

<!-- If the PR is related to an issue, please mention it (for instance "Closes
#619"). -->

Closes #

# Context, Motivation & Description

<!-- If the issue has a clear description, it may be enough; else describe the
changes done in your PR here. -->

# Impact on code generation

<!-- Please describe the impact on VHDL/Verilog/SystemVerilog code generation.
-->

# Checklist

- [ ] Unit tests were added
- [ ] API changes are or will be documented:
  - using Scaladoc comments: `/** */`?
  - on [RTD](https://github.com/SpinalHDL/SpinalDoc-RTD)?
  - thanks to a [new tracking issue on RTD](https://github.com/SpinalHDL/SpinalDoc-RTD/issues/new?title=Document%20XXX&body=Do%20not%20merge%20until%20SpinalHDL/SpinalHDL%23XXX%20has%20not%20been%20merged)?
